### PR TITLE
add support for logging in with 'regular-login'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+*.iml
+.idea
+.eastwood

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ jobs:
     - name: "Latest Grafana"
       env: GRAFANA_TEST_VERSION=${GRAFANA_TEST_VERSION_LATEST}
 before_install:
-  - docker run --rm -d -p 3000:3000 -v "$(pwd)/grafana/datasources":/etc/grafana/provisioning/datasources -v "$(pwd)/grafana/dashboards":/etc/grafana/provisioning/dashboards grafana/grafana:${GRAFANA_TEST_VERSION}
-script: lein do cljfmt check, eastwood, test :all
+  - ./start-grafana.sh
+script: lein lint-and-test
 deploy:
   provider: script
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -467,6 +467,12 @@ user> (core/update-datasource gf-record 1 2 {:name "new-name"})
 user> (core/delete-datasource gf-record 1 2)
 {:status :ok}
 ```
+
+## Running Tests Locally
+```bash
+./run-tests.sh
+```
+
 ## License
 
 Copyright (c) 2019, 2020 Magnet S Coop.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ To use this library add the following key to your configuration:
 
 `:magnet.dashboard-manager/grafana`
 
-This key expects a configuration map with two mandatory keys, plus another three optional ones.
+This key expects a configuration map with two mandatory keys
 These are the mandatory keys:
 
 * `:uri` : The URI where Grafana's server is listening.
 * `:credentials`: A vector with two elements, a username and password, that are used for basic HTTP authentication.
 
 These are the optional keys:
+* `:auth-method`: `:basic-auth` or `:regular-login`; defaults to `:basic-auth`
 * `:timeout`: Timeout value (in milli-seconds) for an connection attempt with Grafana.
 * `:max-retries`: If the connection attempt fails, how many retries we want to attempt before giving up.
 * `:backoff-ms`: This is a vector in the form [initial-delay-ms max-delay-ms multiplier] to control the delay between each retry. The delay for nth retry will be (max (* initial-delay-ms n multiplier) max-delay-ms). If multiplier is not specified (or if it is nil), a multiplier of 2 is used. All times are in milli-seconds.
@@ -79,6 +80,7 @@ Configuration with custom request retry policy:
 
 ### Obtaining a `Grafana` record
 
+#### Using Duct
 If you are using the library as part of a [Duct](https://github.com/duct-framework/duct)-based project, adding any of the previous configurations to your `config.edn` file will perform all the steps necessary to initialize the key and return a `Grafana` record for the associated configuration. In order to show a few interactive usages of the library, we will do all the steps manually in the REPL.
 
 First we require the relevant namespaces:
@@ -124,6 +126,19 @@ user> gf-record
                                           :backoff-ms [500 1000 2.0]}
 user>
 ```
+#### Not using Duct
+
+```clj
+user> (require '[magnet.dashboard-manager.grafana :as grafana])
+      (grafana/connect "http://localhost:4000", ["admin" "adamin"])
+#magnet.dashboard_manager.grafana.Grafana{:uri "http://localhost:4000",
+                                          :credentials ["admin"
+                                                        "admin"],
+                                          :timeout 200,
+                                          :max-retries 10,
+                                          :backoff-ms [500 1000 2.0]}
+```
+
 Now that we have our `Grafana` record, we are ready to use the methods defined by the protocols defined in `magnet.dashboard-manager.core` namespace.
 
 ### Managing organizations
@@ -268,6 +283,18 @@ user> (core/get-user gf-record "login")
 * parameters:
   - A `Grafana` record
   - User ID
+* returning value:
+  - `:status`: `:ok`, `:access-denied`, `:not-found`, `:unknown-host`, `:connection-refused`, `:error`, `not-found`
+  - `:orgs`: A vector of maps. Each map representing an organization.
+* Example:
+```clj
+user> (core/get-user-orgs gf-record 1)
+{:status :ok :orgs [{:orgId 1, :name "Main Org.", :role "Admin"}]}
+```
+#### `get-current-user-orgs`
+* description: Gets a list of organizations to which currently logged in user belongs.
+* parameters:
+  - A `Grafana` record
 * returning value:
   - `:status`: `:ok`, `:access-denied`, `:not-found`, `:unknown-host`, `:connection-refused`, `:error`, `not-found`
   - `:orgs`: A vector of maps. Each map representing an organization.

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                                       :username :env/clojars_username
                                       :password :env/clojars_password
                                       :sign-releases false}]]
+  :aliases {"lint-and-test" ["do" ["cljfmt" "check"] "eastwood" ["test" ":all"]]}
   :profiles {:dev [:project/dev :profiles/dev]
              :profiles/dev {}
              :project/dev {:plugins [[jonase/eastwood "0.3.11"]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,11 @@
+export GRAFANA_TEST_USERNAME=admin
+export GRAFANA_TEST_PASSWORD=admin
+export GRAFANA_TEST_URI=http://localhost:3000
+
+export GRAFANA_TEST_CONTAINER_ID=`GRAFANA_TEST_VERSION=6.2.5 ./start-grafana.sh`
+lein lint-and-test
+./stop-grafana.sh
+
+export GRAFANA_TEST_CONTAINER_ID=`GRAFANA_TEST_VERSION=6.6.0 ./start-grafana.sh`
+lein lint-and-test
+./stop-grafana.sh

--- a/start-grafana.sh
+++ b/start-grafana.sh
@@ -1,0 +1,1 @@
+docker run --rm -d -p 3000:3000 -v "$(pwd)/grafana/datasources":/etc/grafana/provisioning/datasources -v "$(pwd)/grafana/dashboards":/etc/grafana/provisioning/dashboards grafana/grafana:${GRAFANA_TEST_VERSION}

--- a/stop-grafana.sh
+++ b/stop-grafana.sh
@@ -1,0 +1,1 @@
+docker kill $GRAFANA_TEST_CONTAINER_ID

--- a/test/magnet/dashboard_manager/grafana_test.clj
+++ b/test/magnet/dashboard_manager/grafana_test.clj
@@ -304,3 +304,12 @@
     (testing "delete non existing datasource"
       (let [result (dm-core/delete-datasource gf-boundary 1 (rand-int 1000))]
         (is (= :error (:status result)))))))
+
+(deftest ^:integration regular-login-test
+  (let [gf-boundary (ig/init-key :magnet.dashboard-manager/grafana (assoc test-config :auth-method :regular-login))]
+    (testing "regular login should yield the session cookie"
+      (is (str/starts-with? (:session-cookie gf-boundary) dm-grafana/grafana-session-cookie)))
+    (testing "logged in user should be able to get orgs that he belongs to"
+      (let [{:keys [status orgs]} (dm-grafana/gf-get-current-user-orgs gf-boundary)]
+        (is (= :ok status))
+        (is (pos? (count orgs)))))))


### PR DESCRIPTION
This PR adds support for "regular authentication", which is in force when "basic authentication" is disabled.  This term is a bit odd, but trying to be consistent with wording on https://grafana.com/docs/grafana/latest/http_api/auth/#tokens

